### PR TITLE
Fix critical bug with PassMoves that would cause disqualification

### DIFF
--- a/src/communication/sc_MessageHandler.cpp
+++ b/src/communication/sc_MessageHandler.cpp
@@ -121,7 +121,7 @@ namespace SC_Communication {
             destinationNode.append_attribute("z").set_value(move.GetDestinationPosition().GetZ());
         } else if (move.GetMoveType() == Hive::MoveType::PassMove) {
             pugi::xml_node dataNode = roomNode.append_child("data");
-            dataNode.append_attribute("class").set_value("missmove");
+            dataNode.append_attribute("class").set_value("skipmove");
         }
 
         Util::XMLStringWriter xmlStringWriter;


### PR DESCRIPTION
The fixed bug causes a disqualification of the client every time it sends a move of type PassMove